### PR TITLE
Fixing command for search in cluster mode

### DIFF
--- a/src/main/java/io/redisearch/client/Commands.java
+++ b/src/main/java/io/redisearch/client/Commands.java
@@ -39,7 +39,7 @@ import redis.clients.jedis.util.SafeEncoder;
         ADD("FT.ADD"),
         ADDHASH("FT.ADDHASH"),
         INFO("FT.INFO"),
-        SEARCH("FT.FSEARCH"),
+        SEARCH("FT.SEARCH"),
         EXPLAIN("FT.EXPLAIN"),
         DEL("FT.DEL"),
         DROP("FT.DROP"),


### PR DESCRIPTION
FT.SEARCH is the correct command for search in cluster mode