### PR TITLE
Avoid resource leak in aggregate() using try-with-resource

### DIFF
--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -202,11 +202,12 @@ public class Client {
         ArrayList<byte[]> args = new ArrayList<>();
         args.add(indexName.getBytes());
         q.serializeRedisArgs(args);
-
-        Jedis conn = _conn();
-        List<Object> resp = sendCommand(conn, commands.getAggregateCommand(), args.toArray(new byte[args.size()][])).getObjectMultiBulkReply();
-        conn.close();
-        return new AggregationResult(resp);
+        
+        try (Jedis conn = _conn()) {
+            List<Object> resp = sendCommand(conn, commands.getAggregateCommand(), args.toArray(new byte[args.size()][]))
+                    .getObjectMultiBulkReply();
+            return new AggregationResult(resp);
+        }
     }
 
     /**


### PR DESCRIPTION
aggregate() method of io.redisearch.client.Client can possibly lead to jedis connection resource leak when sendCommand() throws exception. 

Avoiding resource leakage using try-with-resource approach as Jedis implements AutoCloseable interface.