### PR TITLE
Constructor for ClusterClient to connect to a password protected Redis.

### DIFF
--- a/src/main/java/io/redisearch/client/ClusterClient.java
+++ b/src/main/java/io/redisearch/client/ClusterClient.java
@@ -22,6 +22,20 @@ public class ClusterClient extends Client {
         this.commands = new Commands.ClusterCommands();
     }
 
+    /**
+     * Create a new ClusterClient to a RediSearch index which can connect to password protected
+     * Redis Server
+     *
+     * @param indexName the name of the index we are connecting to or creating
+     * @param host      the redis host
+     * @param port      the redis pot
+     * @param password  the password for authentication in a password protected Redis server
+     */
+    public ClusterClient(String indexName, String host, int port, int timeout, int poolSize, String password) {
+        super(indexName, host, port, timeout, poolSize, password);
+        this.commands = new Commands.ClusterCommands();
+    }
+
     public ClusterClient(String indexName, String host, int port) {
         this(indexName, host, port, 500, 100);
     }

--- a/src/test/java/io/redisearch/client/ClusterTest.java
+++ b/src/test/java/io/redisearch/client/ClusterTest.java
@@ -25,8 +25,8 @@ public class ClusterTest {
     static String CLUSTER_HOST = System.getProperty("redis.cluster.host", "localhost");
     static String CLUSTER_INDEX = System.getProperty("redis.cluster.rsIndex", "testung");
 
-    static String PROTECTED_CLUSTER_HOST = System.getProperty("redis.protected.cluster.host", "172.16.48.167");
-    static int PROTECTED_CLUSTER_PORT = Integer.parseInt(System.getProperty("redis.protected.cluster.port", "7001"));
+    static String PROTECTED_CLUSTER_HOST = System.getProperty("redis.protected.cluster.host", "localhost");
+    static int PROTECTED_CLUSTER_PORT = Integer.parseInt(System.getProperty("redis.protected.cluster.port", "7000"));
     static String PROTECTD_CLUSTER_PASSWORD = System.getProperty("redis.protected.cluster.password", "password");
     static String WRONG_PASSWORD = System.getProperty("redis.wrong.password", "wrong pass");
     static  int TIMEOUT = Integer.parseInt(System.getProperty("redis.cluster.timeout", "500"));


### PR DESCRIPTION
RediSearch client provides option to connect to a password protected Redis Server whereas ClusterClient doesn't have option to connect to password protected Redis Server.

Exposing a new constructor in ClusterClient to accept password string.

@itamarhaber @mnunberg @dvirsky Could you guys please take a look into the PR.