### PR TITLE
NOSTEM must be before SORTABLE in TextField

### DIFF
--- a/src/main/java/io/redisearch/Schema.java
+++ b/src/main/java/io/redisearch/Schema.java
@@ -90,11 +90,11 @@ public class Schema {
                 args.add("WEIGHT");
                 args.add(Double.toString(weight));
             }
-            if (sortable) {
-                args.add("SORTABLE");
-            }
             if (nostem) {
                 args.add("NOSTEM");
+            }
+            if (sortable) {
+                args.add("SORTABLE");
             }
             if (noindex) {
                 args.add("NOINDEX");


### PR DESCRIPTION
It is not possible to combine sortable:true and nostem:true in Schema.TextField constructor.
I switched position of NOSTEM and SORTABLE to follow redis ft.create schema documentation.

